### PR TITLE
build: rename prerelease script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "doc": "doctoc README.md",
     "release": "HUSKY_SKIP_HOOKS=1 standard-version",
     "postrelease": "npm run push && npm publish",
-    "next": "HUSKY_SKIP_HOOKS=1 standard-version --prerelease",
-    "postnext": "npm run push && npm publish --tag next",
+    "pre-release": "HUSKY_SKIP_HOOKS=1 standard-version --prerelease",
+    "postpre-release": "npm run push && npm publish --tag prerelease",
     "push": "git push origin --follow-tags `git rev-parse --abbrev-ref HEAD`"
   },
   "repository": {


### PR DESCRIPTION
Rename script and use the `prerelease` as a tag name in npm.