### PR TITLE
build: activate ts linting

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import { EventEmitter } from 'events' // eslint-disable-line no-unused-vars
 
 declare namespace Doc {
   interface DocOptions {
@@ -109,6 +109,6 @@ declare namespace Doc {
   }
 }
 
-declare function Doc(options?: Doc.DocOptions): Doc.DocInstance
+declare function Doc(options?: Doc.DocOptions): Doc.DocInstance // eslint-disable-line no-redeclare
 
 export = Doc

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -5,5 +5,6 @@ module.exports = {
     const list = filenames.map(filename => `'markdown-toc -i ${filename}`)
     return list
   },
-  '*.{js,d.ts}': ['standard --fix']
+  '*.{js}': ['standard --fix'],
+  '*.{d.ts}': ['standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin --fix']
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "is-ci": "^2.0.0",
     "lint-staged": "^10.2.10",
     "markdown-toc": "^1.2.0",
-    "semver": "^7.3.2",
     "standard": "^14.3.4",
     "standard-version": "^8.0.0",
     "tap": "^14.10.7",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "lint": "standard --fix && npm run lint:typescript",
-    "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin *.ts",
-    "test": "tap test.js && npm run test:typescript",
-    "test:typescript": "tsd",
+    "lint": "npm run lint:js && npm run lint:ts",
+    "lint:js": "standard --fix",
+    "lint:ts": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin *.ts",
+    "test": "npm run lint && npm run test:js && npm run test:ts",
+    "test:js": "tap test.js",
+    "test:ts": "tsd",
     "doc": "markdown-toc -i README.md",
     "release": "HUSKY_SKIP_HOOKS=1 standard-version",
     "postrelease": "npm run push && npm publish",
@@ -48,11 +50,6 @@
   "engines": {
     "node": ">=10",
     "npm": ">=6"
-  },
-  "standard": {
-    "ignore": [
-      "index.d.ts"
-    ]
   },
   "tsd": {
     "directory": "."

--- a/test.js
+++ b/test.js
@@ -3,17 +3,16 @@
 const tap = require('tap')
 const { monitorEventLoopDelay, constants } = require('perf_hooks')
 const isCi = require('is-ci')
-const semver = require('semver')
 const doc = require('./')
 const GCStats = require('./gc')
 
+const nodeMajorVersion = parseInt(process.versions.node.split('.')[0])
 const performDetailedCheck = process.platform === 'linux' || !isCi
-const isGte12 = semver.gte(process.versions.node, '12.0.0')
 
 const checks = {
   eventLoopDelay (value) {
     if (performDetailedCheck) {
-      const level = isGte12 ? 1 : 20
+      const level = nodeMajorVersion >= 12 ? 1 : 20
       return value > 0 && value < level
     }
     return value >= 0
@@ -27,21 +26,21 @@ const checks = {
   },
   rss (value) {
     if (performDetailedCheck) {
-      const level = isGte12 ? 130 : 150
+      const level = nodeMajorVersion >= 12 ? 130 : 150
       return value > 0 && value < level * 1e6
     }
     return value > 0
   },
   heapTotal (value) {
     if (performDetailedCheck) {
-      const level = isGte12 ? 80 : 100
+      const level = nodeMajorVersion >= 12 ? 80 : 100
       return value > 0 && value < level * 1e6
     }
     return value > 0
   },
   heapUsed (value) {
     if (performDetailedCheck) {
-      const level = isGte12 ? 60 : 80
+      const level = nodeMajorVersion >= 12 ? 60 : 80
       return value > 0 && value < level * 1e6
     }
     return value > 0


### PR DESCRIPTION
Activate linting of types with standard, excluding lines that are known
to report false errors.
Fix lint-staged config for linting ts files and organize better npm
scripts.

Related #21 