### PR TITLE
fix(sampler): pass options from kOptions

### DIFF
--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -31,7 +31,7 @@ class Sampler extends EventEmitter {
     this[kLastSampleTime] = process.hrtime()
 
     if (this[kOptions].collect.eventLoopDelay) {
-      this[kEventLoopDelay] = new EventLoopDelayMetric(options.eventLoopOptions)
+      this[kEventLoopDelay] = new EventLoopDelayMetric(this[kOptions].eventLoopOptions)
     }
 
     if (this[kOptions].collect.cpu) {

--- a/test/doc.test.js
+++ b/test/doc.test.js
@@ -80,7 +80,7 @@ const checks = {
     let check
     let expected
     if (performDetailedCheck) {
-      const level = 10 * 11e5
+      const level = 10 * 15e5
       check = value > 0 && value < level
       expected = `0 < x < ${level}`
     } else {


### PR DESCRIPTION
Pass options to eventLoopDelayMetric from the validated kOptions object
for consistency. Increase a bit external mem check, with newer version
of Node it seems to be increased.