### PR TITLE
fix(gc): add start and stop

### DIFF
--- a/lib/gc.js
+++ b/lib/gc.js
@@ -18,7 +18,9 @@ const hdr = require('hdr-histogram-js')
 const {
   kSample,
   kReset,
-  kObserverCallback
+  kObserverCallback,
+  kStart,
+  kStop
 } = require('./symbols')
 
 hdr.initWebAssemblySync()
@@ -156,6 +158,8 @@ class GCMetric {
     this[kPause] = new GCEntry()
     if (aggregate) {
       const Entry = flags ? GCAggregatedEntry : GCEntry
+      // TODO: this can be converted to a simple object, maybe?
+      // I'll have to run deoptigate.
       this[kGCEntries] = new Map([
         [NODE_PERFORMANCE_GC_MAJOR, new Entry(flags)],
         [NODE_PERFORMANCE_GC_MINOR, new Entry(flags)],
@@ -167,13 +171,20 @@ class GCMetric {
     }
 
     this[kObserver] = new PerformanceObserver(this[kObserverCallback].bind(this))
-    this[kObserver].observe({ entryTypes: ['gc'], buffered: true })
   }
 
   [kObserverCallback] (list) {
     for (const gcEntry of list.getEntries()) {
       this[kSample](gcEntry)
     }
+  }
+
+  [kStart] () {
+    this[kObserver].observe({ entryTypes: ['gc'], buffered: true })
+  }
+
+  [kStop] () {
+    this[kObserver].disconnect()
   }
 
   [kReset] () {

--- a/lib/sampler.js
+++ b/lib/sampler.js
@@ -22,7 +22,9 @@ const {
   kMemory,
   kEmitSample,
   kSample,
-  kReset
+  kReset,
+  kStart,
+  kStop
 } = require('./symbols')
 
 class Sampler extends EventEmitter {
@@ -59,6 +61,9 @@ class Sampler extends EventEmitter {
 
   start () {
     if (this[kStarted]) return
+    if (this[kOptions].collect.gc) {
+      this[kGC][kStart]()
+    }
     this[kTimer] = setInterval(this[kEmitSample].bind(this), this[kOptions].sampleInterval)
     if (this[kOptions].unref) {
       this[kTimer].unref()
@@ -69,6 +74,10 @@ class Sampler extends EventEmitter {
   stop () {
     clearInterval(this[kTimer])
     this[kStarted] = false
+    this[kReset]()
+    if (this[kOptions].collect.gc) {
+      this[kGC][kStop]()
+    }
   }
 
   get cpu () {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -14,6 +14,7 @@ module.exports = {
   kMemory: Symbol('kMemory'),
   kEmitSample: Symbol('kEmitSample'),
   kStart: Symbol('kStart'),
+  kStop: Symbol('kStop'),
   kSample: Symbol('kSample'),
   kReset: Symbol('kReset'),
   kRawMetric: Symbol('kRawMetric'),


### PR DESCRIPTION
The gc metrics required a start and stop method to effectively start and
stop with the Sampler instance.