### PR TITLE
build: use new env var to disable husky on releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "bench:doc:resourceUsage": "PORT=3000 concurrently -k -s first \"node benchmarks/docResourceUsage.js\" \"node -e 'setTimeout(()=>{}, 1000)' && autocannon -d 60 -c 100 -p 10 localhost:3000\"",
     "doc": "markdown-toc -i README.md",
     "prerelease": "npm cit",
-    "release": "HUSKY_SKIP_HOOKS=1 standard-version --sign",
+    "release": "HUSKY=0 standard-version --sign",
     "postrelease": "npm run push && npm publish",
     "prenext": "npm cit",
-    "next": "HUSKY_SKIP_HOOKS=1 standard-version --sign --prerelease",
+    "next": "HUSKY=0 standard-version --sign --prerelease",
     "postnext": "npm run push && npm publish --tag next",
     "push": "git push origin --follow-tags `git rev-parse --abbrev-ref HEAD`"
   },


### PR DESCRIPTION
See https://typicode.github.io/husky/#/?id=disable-hooks-in-ci.